### PR TITLE
Fix case sensitivity in extension validators

### DIFF
--- a/flutter_ui_bloc/lib/src/form/fields/base/upload_file_field_bloc_builder_widgets.dart
+++ b/flutter_ui_bloc/lib/src/form/fields/base/upload_file_field_bloc_builder_widgets.dart
@@ -41,7 +41,13 @@ class FileFieldView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final mimeType = lookupMimeType(file.name);
+    String? mimeType = lookupMimeType(file.name);
+
+    // This is a quick fix until https://github.com/dart-lang/mime/pull/58 gets published
+    if (mimeType == null && file.name.toLowerCase().endsWith("heic")) {
+      mimeType = "image/heic";
+    }
+
     if (mimeType != null && mimeType.startsWith('image')) {
       return _ImageFileFieldView(file: file);
     }

--- a/flutter_ui_bloc/lib/src/form/fields/base/upload_file_field_bloc_builder_widgets.dart
+++ b/flutter_ui_bloc/lib/src/form/fields/base/upload_file_field_bloc_builder_widgets.dart
@@ -44,7 +44,7 @@ class FileFieldView extends StatelessWidget {
     String? mimeType = lookupMimeType(file.name);
 
     // This is a quick fix until https://github.com/dart-lang/mime/pull/58 gets published
-    if (mimeType == null && file.name.toLowerCase().endsWith("heic")) {
+    if (mimeType == null && file.name.toLowerCase().endsWith(".heic")) {
       mimeType = "image/heic";
     }
 

--- a/flutter_ui_bloc/lib/src/form/validation/validation.dart
+++ b/flutter_ui_bloc/lib/src/form/validation/validation.dart
@@ -324,14 +324,17 @@ class FileValidation extends ValidationBase<XFile> {
 
   @override
   Object? call(XFile value) {
-    if (whereExtensionIn != null && !whereExtensionIn!.any(value.name.endsWith)) {
+    final name = value.name.toLowerCase();
+    if (whereExtensionIn != null &&
+        !whereExtensionIn!.map((e) => e.toLowerCase()).any(name.endsWith)) {
       return FileValidationError(
         validation: this,
         code: errorCode,
         whereExtensionIn: whereExtensionIn,
         whereExtensionNotIn: whereExtensionNotIn,
       );
-    } else if (whereExtensionNotIn != null && whereExtensionNotIn!.any(value.name.endsWith)) {
+    } else if (whereExtensionNotIn != null &&
+        whereExtensionNotIn!.map((e) => e.toLowerCase()).any(name.endsWith)) {
       return FileValidationError(
         validation: this,
         code: errorCode,

--- a/flutter_ui_bloc/test/form/fields/utils/value_validators_test.dart
+++ b/flutter_ui_bloc/test/form/fields/utils/value_validators_test.dart
@@ -95,9 +95,21 @@ void main() {
           isNull,
         );
       });
+      test('"home/image.png"{whereExtensionIn: [\'png\']}->🟢', () {
+        expect(
+          const FileValidation(whereExtensionIn: ['png']).call(XFile('home/image.PNG')),
+          isNull,
+        );
+      });
       test('"home/image.png"{whereExtensionNotIn: [\'png\']}->🟢', () {
         expect(
           const FileValidation(whereExtensionNotIn: ['png']).call(XFile('home/image.png')),
+          isNotNull,
+        );
+      });
+      test('"home/image.png"{whereExtensionNotIn: [\'png\']}->🟢', () {
+        expect(
+          const FileValidation(whereExtensionNotIn: ['png']).call(XFile('home/image.PNG')),
           isNotNull,
         );
       });

--- a/flutter_ui_bloc/test/form/fields/utils/value_validators_test.dart
+++ b/flutter_ui_bloc/test/form/fields/utils/value_validators_test.dart
@@ -95,7 +95,7 @@ void main() {
           isNull,
         );
       });
-      test('"home/image.png"{whereExtensionIn: [\'png\']}->🟢', () {
+      test('"home/image.PNG"{whereExtensionIn: [\'png\']}->🟢', () {
         expect(
           const FileValidation(whereExtensionIn: ['png']).call(XFile('home/image.PNG')),
           isNull,
@@ -107,7 +107,7 @@ void main() {
           isNotNull,
         );
       });
-      test('"home/image.png"{whereExtensionNotIn: [\'png\']}->🟢', () {
+      test('"home/image.PNG"{whereExtensionNotIn: [\'png\']}->🟢', () {
         expect(
           const FileValidation(whereExtensionNotIn: ['png']).call(XFile('home/image.PNG')),
           isNotNull,


### PR DESCRIPTION
Fix missing heic format handling.

TLDR;

- File extension validation is failing when filename and declared set of supported / unsupported extension have different case.
- The `mime` package is not supporting `heic` format (https://github.com/dart-lang/mime/pull/58)